### PR TITLE
Move numMarkers as an argument of search()

### DIFF
--- a/lib/src/geocoder_offline_base.dart
+++ b/lib/src/geocoder_offline_base.dart
@@ -56,9 +56,6 @@ class GeocodeData {
   /// Name of column that contains Location longitude
   final String longitudeHeader;
 
-  /// Number of nearest result
-  final int numMarkers;
-
   late KDTree _kdTree;
   late int _featureNameHeaderSN;
   late int _stateHeaderSN;
@@ -67,8 +64,7 @@ class GeocodeData {
 
   GeocodeData(this.inputString, this.featureNameHeader, this.stateHeader,
       this.latitudeHeader, this.longitudeHeader,
-      {this.numMarkers = 1,
-      this.fieldDelimiter = defaultFieldDelimiter,
+      {this.fieldDelimiter = defaultFieldDelimiter,
       this.textDelimiter = defaultTextDelimiter,
       this.eol = defaultEol}) {
     var rowsAsListOfValues = const CsvToListConverter().convert(inputString,
@@ -142,7 +138,8 @@ class GeocodeData {
     return bearings[index];
   }
 
-  List<LocationResult> search(double latitute, double longitude) {
+  List<LocationResult> search(double latitute, double longitude,
+      {int numMarkers = 1}) {
     var result = <LocationResult>[];
     var point = {'latitude': latitute, 'longitude': longitude};
     var nearest = _kdTree.nearest(point, numMarkers);

--- a/test/geocoder_offline_test.dart
+++ b/test/geocoder_offline_test.dart
@@ -20,10 +20,9 @@ void main() {
         'PRIMARY_LATITUDE',
         'PRIMARY_LONGITUDE',
         fieldDelimiter: ',',
-        eol: '\n',
-        numMarkers: 1);
+        eol: '\n');
 
-    var result = geocoder.search(41.881832, -87.623177);
+    var result = geocoder.search(41.881832, -87.623177, numMarkers: 1);
     expect(result.length, 1);
     expect(result.first.distance.toInt(), 1);
     expect(result.first.bearing, 'ESE');
@@ -40,10 +39,9 @@ void main() {
         'latitude',
         'longitude',
         fieldDelimiter: '\t',
-        eol: '\n',
-        numMarkers: 1);
+        eol: '\n');
 
-    var result = geocoder.search(41.881832, -87.623177);
+    var result = geocoder.search(41.881832, -87.623177, numMarkers: 1);
     expect(result.length, 1);
     expect(result.first.distance.toInt(), 0);
     expect(result.first.bearing, 'E');

--- a/test/geocoder_offline_test.dart
+++ b/test/geocoder_offline_test.dart
@@ -48,4 +48,27 @@ void main() {
     expect(result.first.location.featureName, 'Chicago Loop');
     expect(result.first.gnisFormat.trim(), 'Chicago Loop, US');
   });
+
+  test('Test number of nearest result', () {
+    var geocoder = GeocodeData(
+        File(Directory.current.path + '/example/cities15000.txt')
+            .readAsStringSync(),
+        'name',
+        'country code',
+        'latitude',
+        'longitude',
+        fieldDelimiter: '\t',
+        eol: '\n');
+
+    var result = geocoder.search(41.881832, -87.623177, numMarkers: 2);
+    expect(result.length, 2);
+    expect(result.first.distance.toInt(), 1);
+    expect(result.first.bearing, 'SE');
+    expect(result.first.location.featureName, 'Near North Side');
+    expect(result.first.gnisFormat.trim(), '1mi SE of Near North Side, US');
+    expect(result.last.distance.toInt(), 0);
+    expect(result.last.bearing, 'E');
+    expect(result.last.location.featureName, 'Chicago Loop');
+    expect(result.last.gnisFormat.trim(), 'Chicago Loop, US');
+  });
 }


### PR DESCRIPTION
Allows doing multiple searches with different marker limits on the same
location data set.